### PR TITLE
Add patch to use native file chooser

### DIFF
--- a/com.github.bleakgrey.tootle.json
+++ b/com.github.bleakgrey.tootle.json
@@ -29,6 +29,10 @@
                 "type": "archive",
                 "url": "https://github.com/bleakgrey/tootle/archive/0.1.5.tar.gz",
                 "sha256": "77b441df19b4d9f885b95510712f25b5e6719a27cdb527831e03212063df88d1"
+            },
+            {
+                "type": "patch",
+                "path": "native-file-chooser.patch"
             }]
         }
     ]

--- a/native-file-chooser.patch
+++ b/native-file-chooser.patch
@@ -1,0 +1,29 @@
+diff --git a/src/Widgets/AttachmentBox.vala b/src/Widgets/AttachmentBox.vala
+index 11d744f..04ea465 100644
+--- a/src/Widgets/AttachmentBox.vala
++++ b/src/Widgets/AttachmentBox.vala
+@@ -36,14 +36,12 @@ public class Tootle.AttachmentBox : Gtk.ScrolledWindow {
+         filter.add_mime_type ("video/webm");
+         filter.add_mime_type ("video/mp4");
+         
+-        var chooser = new Gtk.FileChooserDialog (
++        var chooser = new Gtk.FileChooserNative (
+             _("Select media files to add"),
+             null,
+             Gtk.FileChooserAction.OPEN,
+-            _("_Cancel"),
+-            Gtk.ResponseType.CANCEL,
+             _("_Open"),
+-            Gtk.ResponseType.ACCEPT);
++            _("_Cancel"));
+         
+         chooser.select_multiple = true;
+         chooser.set_filter (filter);
+@@ -55,7 +53,6 @@ public class Tootle.AttachmentBox : Gtk.ScrolledWindow {
+                 box.pack_start (widget, false, false, 6);
+             }
+         }
+-        chooser.close ();
+     }
+     
+     public string get_uri_array () {


### PR DESCRIPTION
This allows attaching media to toots from the sandbox and solves #1. 