### PR TITLE
Update runtime to version 41

### DIFF
--- a/Adhere-to-GLib.Object-naming-conventions.patch
+++ b/Adhere-to-GLib.Object-naming-conventions.patch
@@ -1,0 +1,69 @@
+From da4bcf5afa1df36fb5c6cb2dc175600911252d9b Mon Sep 17 00:00:00 2001
+From: Clayton Craft <clayton@craftyguy.net>
+Date: Tue, 26 Oct 2021 15:03:25 -0700
+Subject: [PATCH] Adhere to GLib.Object naming conventions for properties
+
+Vala now validates property names against GLib.Object conventions, this
+fixes a compilation error as a result of this enforcement:
+
+../src/API/Status.vala:27.5-27.23: error: Name `_url' is not valid for a GLib.Object property
+    public string? _url { get; set; }
+    ^^^^^^^^^^^^^^^^^^^
+
+Relevant Vala change:
+https://gitlab.gnome.org/GNOME/vala/-/commit/38d61fbff037687ea4772e6df85c7e22a74b335e
+
+fixes #337
+
+Signed-off-by: Clayton Craft <clayton@craftyguy.net>
+---
+ src/API/Attachment.vala | 6 +++---
+ src/API/Status.vala     | 8 ++++----
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/API/Attachment.vala b/src/API/Attachment.vala
+index 5c66e79..3749bd7 100644
+--- a/src/API/Attachment.vala
++++ b/src/API/Attachment.vala
+@@ -32,10 +32,10 @@ public class Tootle.API.Attachment : Entity {
+ 	public string kind { get; set; }
+ 	public string url { get; set; }
+ 	public string? description { get; set; }
+-	public string? _preview_url { get; set; }
++	private string? t_preview_url { get; set; }
+ 	public string? preview_url {
+-		set { this._preview_url = value; }
+-		get { return (this._preview_url == null || this._preview_url == "") ? url : _preview_url; }
++		set { this.t_preview_url = value; }
++		get { return (this.t_preview_url == null || this.t_preview_url == "") ? url : t_preview_url; }
+ 	}
+ 
+ 	public static Attachment from (Json.Node node) throws Error {
+diff --git a/src/API/Status.vala b/src/API/Status.vala
+index 4de9b9d..7ebb2e5 100644
+--- a/src/API/Status.vala
++++ b/src/API/Status.vala
+@@ -24,16 +24,16 @@ public class Tootle.API.Status : Entity, Widgetizable {
+     public ArrayList<API.Mention>? mentions { get; set; default = null; }
+     public ArrayList<API.Attachment>? media_attachments { get; set; default = null; }
+ 
+-    public string? _url { get; set; }
++    private string? t_url { get; set; }
+     public string url {
+         owned get { return this.get_modified_url (); }
+-        set { this._url = value; }
++        set { this.t_url = value; }
+     }
+     string get_modified_url () {
+-        if (this._url == null) {
++        if (this.t_url == null) {
+             return this.uri.replace ("/activity", "");
+         }
+-        return this._url;
++        return this.t_url;
+     }
+ 
+     public Status formal {
+-- 
+2.33.1
+

--- a/Application-make-app_entries-private.patch
+++ b/Application-make-app_entries-private.patch
@@ -1,0 +1,26 @@
+From ee278f143f307dd1396afe3eb79237a027cc7b90 Mon Sep 17 00:00:00 2001
+From: Bobby Rong <rjl931189261@126.com>
+Date: Sat, 19 Mar 2022 16:59:31 +0800
+Subject: [PATCH] Application: make app_entries private
+
+Fixes compilation with latest valac.
+---
+ src/Application.vala | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Application.vala b/src/Application.vala
+index 3b2c9b9..09556bb 100644
+--- a/src/Application.vala
++++ b/src/Application.vala
+@@ -43,7 +43,7 @@ namespace Tootle {
+ 			{ null }
+ 		};
+ 
+-		public const GLib.ActionEntry[] app_entries = {
++		private const GLib.ActionEntry[] app_entries = {
+ 			{ "about", about_activated },
+ 			{ "compose", compose_activated },
+ 			{ "back", back_activated },
+-- 
+2.35.1
+

--- a/Use-reason_phrase-instead-of-get_phrase.patch
+++ b/Use-reason_phrase-instead-of-get_phrase.patch
@@ -1,0 +1,51 @@
+From 858ee78fbebe161a4cdd707a469dc0f045211a51 Mon Sep 17 00:00:00 2001
+From: Max Harmathy <harmathy@mailbox.org>
+Date: Wed, 25 Aug 2021 13:05:58 +0200
+Subject: [PATCH] Use reason_phrase instead of get_phrase
+
+---
+ src/Services/Cache.vala   | 2 +-
+ src/Services/Network.vala | 7 +------
+ 2 files changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/src/Services/Cache.vala b/src/Services/Cache.vala
+index 2251697..2ed314e 100644
+--- a/src/Services/Cache.vala
++++ b/src/Services/Cache.vala
+@@ -88,7 +88,7 @@ public class Tootle.Cache : GLib.Object {
+                 try {
+                     var code = msg.status_code;
+ 					if (code != Soup.Status.OK) {
+-					    var error = network.describe_error (code);
++					    var error = msg.reason_phrase;
+ 					    throw new Oopsie.INSTANCE (@"Server returned $error");
+ 					}
+ 
+diff --git a/src/Services/Network.vala b/src/Services/Network.vala
+index fa2839c..d0143b0 100644
+--- a/src/Services/Network.vala
++++ b/src/Services/Network.vala
+@@ -56,7 +56,7 @@ public class Tootle.Network : GLib.Object {
+                 else if (status == Soup.Status.CANCELLED)
+                     debug ("Message is cancelled. Ignoring callback invocation.");
+                 else
+-                    ecb ((int32) status, describe_error ((int32) status));
++                    ecb ((int32) status, msg.reason_phrase);
+             });
+         }
+         catch (Error e) {
+@@ -65,11 +65,6 @@ public class Tootle.Network : GLib.Object {
+         }
+     }
+ 
+-	public string describe_error (uint code) {
+-	    var reason = Soup.Status.get_phrase (code);
+-		return @"$code: $reason";
+-	}
+-
+     public void on_error (int32 code, string message) {
+         warning (message);
+         app.toast (message);
+-- 
+2.33.0
+

--- a/com.github.bleakgrey.tootle.json
+++ b/com.github.bleakgrey.tootle.json
@@ -2,7 +2,7 @@
   "app-id": "com.github.bleakgrey.tootle",
   "runtime": "org.gnome.Platform",
   "sdk": "org.gnome.Sdk",
-  "runtime-version": "40",
+  "runtime-version": "41",
   "command": "com.github.bleakgrey.tootle",
   "finish-args": [
     "--share=network",

--- a/com.github.bleakgrey.tootle.json
+++ b/com.github.bleakgrey.tootle.json
@@ -24,23 +24,6 @@
   ],
   "modules": [
     {
-      "name": "libhandy",
-      "buildsystem": "meson",
-      "builddir": true,
-      "config-opts": [
-        "-Dexamples=false",
-        "-Dtests=false",
-        "-Dglade_catalog=disabled"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://gitlab.gnome.org/GNOME/libhandy/-/archive/1.0.1/libhandy-1.0.1.tar",
-          "sha256": "86da467c3723c81fc6f1105945141cea1e9698a6bb3075637bfb58b2cbfeccd0"
-        }
-      ]
-    },
-    {
       "name": "tootle",
       "builddir": true,
       "buildsystem": "meson",

--- a/com.github.bleakgrey.tootle.json
+++ b/com.github.bleakgrey.tootle.json
@@ -27,12 +27,25 @@
       "name": "tootle",
       "builddir": true,
       "buildsystem": "meson",
-      "sources": [{
-        "type": "archive",
-        "url": "https://github.com/bleakgrey/tootle/archive/1.0.zip",
-        "sha256": "2a398aaddc22a70948bb03d6eb5e64a7ee1f5c63679315939ba47f7938001532"
-      }]
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/bleakgrey/tootle/archive/1.0.zip",
+          "sha256": "2a398aaddc22a70948bb03d6eb5e64a7ee1f5c63679315939ba47f7938001532"
+        },
+        {
+          "type": "patch",
+          "path": "Use-reason_phrase-instead-of-get_phrase.patch"
+        },
+        {
+          "type": "patch",
+          "path": "Adhere-to-GLib.Object-naming-conventions.patch"
+        },
+        {
+          "type": "patch",
+          "path": "Application-make-app_entries-private.patch"
+        }
+      ]
     }
-
   ]
 }


### PR DESCRIPTION
I adjusted the work of #20 and added the patches from my AUR packaging. This would also fix #18 for now.

Updating to version 42 is currently not possible, since the build is broken there even with all the patches due to https://github.com/bleakgrey/tootle/issues/353