### PR TITLE
Update runtime to GNOME 42

### DIFF
--- a/Adhere-to-GLib.Object-naming-conventions.patch
+++ b/Adhere-to-GLib.Object-naming-conventions.patch
@@ -1,0 +1,69 @@
+From da4bcf5afa1df36fb5c6cb2dc175600911252d9b Mon Sep 17 00:00:00 2001
+From: Clayton Craft <clayton@craftyguy.net>
+Date: Tue, 26 Oct 2021 15:03:25 -0700
+Subject: [PATCH] Adhere to GLib.Object naming conventions for properties
+
+Vala now validates property names against GLib.Object conventions, this
+fixes a compilation error as a result of this enforcement:
+
+../src/API/Status.vala:27.5-27.23: error: Name `_url' is not valid for a GLib.Object property
+    public string? _url { get; set; }
+    ^^^^^^^^^^^^^^^^^^^
+
+Relevant Vala change:
+https://gitlab.gnome.org/GNOME/vala/-/commit/38d61fbff037687ea4772e6df85c7e22a74b335e
+
+fixes #337
+
+Signed-off-by: Clayton Craft <clayton@craftyguy.net>
+---
+ src/API/Attachment.vala | 6 +++---
+ src/API/Status.vala     | 8 ++++----
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/API/Attachment.vala b/src/API/Attachment.vala
+index 5c66e79..3749bd7 100644
+--- a/src/API/Attachment.vala
++++ b/src/API/Attachment.vala
+@@ -32,10 +32,10 @@ public class Tootle.API.Attachment : Entity {
+ 	public string kind { get; set; }
+ 	public string url { get; set; }
+ 	public string? description { get; set; }
+-	public string? _preview_url { get; set; }
++	private string? t_preview_url { get; set; }
+ 	public string? preview_url {
+-		set { this._preview_url = value; }
+-		get { return (this._preview_url == null || this._preview_url == "") ? url : _preview_url; }
++		set { this.t_preview_url = value; }
++		get { return (this.t_preview_url == null || this.t_preview_url == "") ? url : t_preview_url; }
+ 	}
+ 
+ 	public static Attachment from (Json.Node node) throws Error {
+diff --git a/src/API/Status.vala b/src/API/Status.vala
+index 4de9b9d..7ebb2e5 100644
+--- a/src/API/Status.vala
++++ b/src/API/Status.vala
+@@ -24,16 +24,16 @@ public class Tootle.API.Status : Entity, Widgetizable {
+     public ArrayList<API.Mention>? mentions { get; set; default = null; }
+     public ArrayList<API.Attachment>? media_attachments { get; set; default = null; }
+ 
+-    public string? _url { get; set; }
++    private string? t_url { get; set; }
+     public string url {
+         owned get { return this.get_modified_url (); }
+-        set { this._url = value; }
++        set { this.t_url = value; }
+     }
+     string get_modified_url () {
+-        if (this._url == null) {
++        if (this.t_url == null) {
+             return this.uri.replace ("/activity", "");
+         }
+-        return this._url;
++        return this.t_url;
+     }
+ 
+     public Status formal {
+-- 
+2.33.1
+

--- a/Application-make-app_entries-private.patch
+++ b/Application-make-app_entries-private.patch
@@ -1,0 +1,26 @@
+From ee278f143f307dd1396afe3eb79237a027cc7b90 Mon Sep 17 00:00:00 2001
+From: Bobby Rong <rjl931189261@126.com>
+Date: Sat, 19 Mar 2022 16:59:31 +0800
+Subject: [PATCH] Application: make app_entries private
+
+Fixes compilation with latest valac.
+---
+ src/Application.vala | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Application.vala b/src/Application.vala
+index 3b2c9b9..09556bb 100644
+--- a/src/Application.vala
++++ b/src/Application.vala
+@@ -43,7 +43,7 @@ namespace Tootle {
+ 			{ null }
+ 		};
+ 
+-		public const GLib.ActionEntry[] app_entries = {
++		private const GLib.ActionEntry[] app_entries = {
+ 			{ "about", about_activated },
+ 			{ "compose", compose_activated },
+ 			{ "back", back_activated },
+-- 
+2.35.1
+

--- a/Fix-construct-prop.patch
+++ b/Fix-construct-prop.patch
@@ -26,7 +26,7 @@ index 3e2fe54..41ed71f 100644
  
          header_icon.visible = header_label.visible = true;
 diff --git a/src/Widgets/Status.vala b/src/Widgets/Status.vala
-index ef51340..763f2ea 100644
+index ef51340..ce1c951 100644
 --- a/src/Widgets/Status.vala
 +++ b/src/Widgets/Status.vala
 @@ -5,7 +5,7 @@ using Gdk;
@@ -47,6 +47,15 @@ index ef51340..763f2ea 100644
  			if (status.reblog != null)
  				kind = API.NotificationType.REBLOG_REMOTE_USER;
  		}
+@@ -164,7 +164,7 @@ public class Tootle.Widgets.Status : ListBoxRow {
+ 		menu_button.clicked.connect (open_menu);
+ 	}
+ 
+-	public Status (owned API.Status status, API.NotificationType? kind = null) {
++	public Status (owned API.Status status, API.NotificationType kind = API.NotificationType.NONE) {
+ 		Object (
+ 			status: status,
+ 			kind: kind
 @@ -180,8 +180,8 @@ public class Tootle.Widgets.Status : ListBoxRow {
  	}
  

--- a/Fix-construct-prop.patch
+++ b/Fix-construct-prop.patch
@@ -1,0 +1,60 @@
+diff --git a/src/API/NotificationType.vala b/src/API/NotificationType.vala
+index c3f4420..15ba2ae 100644
+--- a/src/API/NotificationType.vala
++++ b/src/API/NotificationType.vala
+@@ -5,7 +5,8 @@ public enum Tootle.API.NotificationType {
+     FAVOURITE,
+     FOLLOW,
+     FOLLOW_REQUEST,     // Internal
+-    WATCHLIST;          // Internal
++    WATCHLIST,          // Internal
++    NONE;		// Internal
+ 
+     public string to_string () {
+         switch (this) {
+diff --git a/src/Widgets/Notification.vala b/src/Widgets/Notification.vala
+index 3e2fe54..41ed71f 100644
+--- a/src/Widgets/Notification.vala
++++ b/src/Widgets/Notification.vala
+@@ -16,7 +16,7 @@ public class Tootle.Widgets.Notification : Widgets.Status {
+     }
+ 
+     protected override void on_kind_changed () {
+-        if (kind == null)
++        if (kind == API.NotificationType.NONE)
+             return;
+ 
+         header_icon.visible = header_label.visible = true;
+diff --git a/src/Widgets/Status.vala b/src/Widgets/Status.vala
+index ef51340..763f2ea 100644
+--- a/src/Widgets/Status.vala
++++ b/src/Widgets/Status.vala
+@@ -5,7 +5,7 @@ using Gdk;
+ public class Tootle.Widgets.Status : ListBoxRow {
+ 
+ 	public API.Status status { get; construct set; }
+-	public API.NotificationType? kind { get; construct set; }
++	public API.NotificationType kind { get; construct set; }
+ 
+ 	public enum ThreadRole {
+ 		NONE,
+@@ -113,7 +113,7 @@ public class Tootle.Widgets.Status : ListBoxRow {
+ 		notify["kind"].connect (on_kind_changed);
+ 		open.connect (on_open);
+ 
+-		if (kind == null) {
++		if (kind == API.NotificationType.NONE) {
+ 			if (status.reblog != null)
+ 				kind = API.NotificationType.REBLOG_REMOTE_USER;
+ 		}
+@@ -180,8 +180,8 @@ public class Tootle.Widgets.Status : ListBoxRow {
+ 	}
+ 
+ 	protected virtual void on_kind_changed () {
+-		header_icon.visible = header_label.visible = (kind != null);
+-		if (kind == null)
++		header_icon.visible = header_label.visible = (kind != API.NotificationType.NONE);
++		if (kind == API.NotificationType.NONE)
+ 			return;
+ 
+ 		header_icon.icon_name = kind.get_icon ();

--- a/Use-reason_phrase-instead-of-get_phrase.patch
+++ b/Use-reason_phrase-instead-of-get_phrase.patch
@@ -1,0 +1,51 @@
+From 858ee78fbebe161a4cdd707a469dc0f045211a51 Mon Sep 17 00:00:00 2001
+From: Max Harmathy <harmathy@mailbox.org>
+Date: Wed, 25 Aug 2021 13:05:58 +0200
+Subject: [PATCH] Use reason_phrase instead of get_phrase
+
+---
+ src/Services/Cache.vala   | 2 +-
+ src/Services/Network.vala | 7 +------
+ 2 files changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/src/Services/Cache.vala b/src/Services/Cache.vala
+index 2251697..2ed314e 100644
+--- a/src/Services/Cache.vala
++++ b/src/Services/Cache.vala
+@@ -88,7 +88,7 @@ public class Tootle.Cache : GLib.Object {
+                 try {
+                     var code = msg.status_code;
+ 					if (code != Soup.Status.OK) {
+-					    var error = network.describe_error (code);
++					    var error = msg.reason_phrase;
+ 					    throw new Oopsie.INSTANCE (@"Server returned $error");
+ 					}
+ 
+diff --git a/src/Services/Network.vala b/src/Services/Network.vala
+index fa2839c..d0143b0 100644
+--- a/src/Services/Network.vala
++++ b/src/Services/Network.vala
+@@ -56,7 +56,7 @@ public class Tootle.Network : GLib.Object {
+                 else if (status == Soup.Status.CANCELLED)
+                     debug ("Message is cancelled. Ignoring callback invocation.");
+                 else
+-                    ecb ((int32) status, describe_error ((int32) status));
++                    ecb ((int32) status, msg.reason_phrase);
+             });
+         }
+         catch (Error e) {
+@@ -65,11 +65,6 @@ public class Tootle.Network : GLib.Object {
+         }
+     }
+ 
+-	public string describe_error (uint code) {
+-	    var reason = Soup.Status.get_phrase (code);
+-		return @"$code: $reason";
+-	}
+-
+     public void on_error (int32 code, string message) {
+         warning (message);
+         app.toast (message);
+-- 
+2.33.0
+

--- a/com.github.bleakgrey.tootle.json
+++ b/com.github.bleakgrey.tootle.json
@@ -2,7 +2,7 @@
   "app-id": "com.github.bleakgrey.tootle",
   "runtime": "org.gnome.Platform",
   "sdk": "org.gnome.Sdk",
-  "runtime-version": "41",
+  "runtime-version": "42",
   "command": "com.github.bleakgrey.tootle",
   "finish-args": [
     "--share=network",
@@ -44,6 +44,10 @@
         {
           "type": "patch",
           "path": "Application-make-app_entries-private.patch"
+        },
+        {
+          "type": "patch",
+          "path": "Fix-construct-prop.patch"
         }
       ]
     }

--- a/com.github.bleakgrey.tootle.json
+++ b/com.github.bleakgrey.tootle.json
@@ -2,7 +2,7 @@
   "app-id": "com.github.bleakgrey.tootle",
   "runtime": "org.gnome.Platform",
   "sdk": "org.gnome.Sdk",
-  "runtime-version": "40",
+  "runtime-version": "41",
   "command": "com.github.bleakgrey.tootle",
   "finish-args": [
     "--share=network",

--- a/com.github.bleakgrey.tootle.json
+++ b/com.github.bleakgrey.tootle.json
@@ -24,23 +24,6 @@
   ],
   "modules": [
     {
-      "name": "libhandy",
-      "buildsystem": "meson",
-      "builddir": true,
-      "config-opts": [
-        "-Dexamples=false",
-        "-Dtests=false",
-        "-Dglade_catalog=disabled"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://gitlab.gnome.org/GNOME/libhandy/-/archive/1.0.1/libhandy-1.0.1.tar",
-          "sha256": "86da467c3723c81fc6f1105945141cea1e9698a6bb3075637bfb58b2cbfeccd0"
-        }
-      ]
-    },
-    {
       "name": "tootle",
       "builddir": true,
       "buildsystem": "meson",

--- a/com.github.bleakgrey.tootle.json
+++ b/com.github.bleakgrey.tootle.json
@@ -27,12 +27,25 @@
       "name": "tootle",
       "builddir": true,
       "buildsystem": "meson",
-      "sources": [{
-        "type": "archive",
-        "url": "https://github.com/bleakgrey/tootle/archive/1.0.zip",
-        "sha256": "2a398aaddc22a70948bb03d6eb5e64a7ee1f5c63679315939ba47f7938001532"
-      }]
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/bleakgrey/tootle/archive/1.0.zip",
+          "sha256": "2a398aaddc22a70948bb03d6eb5e64a7ee1f5c63679315939ba47f7938001532"
+        },
+        {
+          "type": "patch",
+          "path": "Use-reason_phrase-instead-of-get_phrase.patch"
+        },
+        {
+          "type": "patch",
+          "path": "Adhere-to-GLib.Object-naming-conventions.patch"
+        },
+        {
+          "type": "patch",
+          "path": "Application-make-app_entries-private.patch"
+        }
+      ]
     }
-
   ]
 }


### PR DESCRIPTION
Based on #21. I could not figure out a way to suggest the addition of a file to a PR, so I created a separate PR based on it. My reasoning for the patch is as follows.
***
Trying to build the PR with GNOME 42, the error I got was the following:

```
../src/Widgets/Status.vala:8.43-8.56: error: construct properties not supported for specified property type
    8 | 	public API.NotificationType? kind { get; construct set; }
      | 	                                         ^~~~~~~~~~~~~~  
```

Searching the Vala compiler repository, the error seems to be emitted from https://gitlab.gnome.org/GNOME/vala/-/blob/main/vala/valapropertyaccessor.vala#L222. I assume that the first part of the condition is true because the property is marked as `construct`. For the second part, I checked the [`is_gobject_property` method](https://gitlab.gnome.org/GNOME/vala/-/blob/main/vala/valasemanticanalyzer.vala#L440). My assumption is that in our case the if clause that is taken to return false (and cause the error) is at [line 454](https://gitlab.gnome.org/GNOME/vala/-/blob/main/vala/valasemanticanalyzer.vala#L454). When I check [the `is_gobject_property_type` method](https://gitlab.gnome.org/GNOME/vala/-/blob/main/vala/valasemanticanalyzer.vala#L484) that is inside the condition, [it returns false](https://gitlab.gnome.org/GNOME/vala/-/blob/main/vala/valasemanticanalyzer.vala#L496) when the type of the property is an enum ([which `API.NotificationType` is](https://github.com/bleakgrey/tootle/blob/af1d8a4a867fa77d4122fa2fa8b5131bd7c3887f/src/API/NotificationType.vala#L1)) and it is nullable (marked with the question mark).

Based on https://naaando.gitbooks.io/the-vala-tutorial/content/en/4-object-oriented-programming/gobject-style-construction.html, the `constructor set` style is for GObject-style construction. I guess (based on the code trail above) the issue is that the type of the property is not compatible with that style. Changing the setting of the property in the constructor to ["the Java/C#-style"](https://naaando.gitbooks.io/the-vala-tutorial/content/en/4-object-oriented-programming/construction.html) allowed me to build the code with the version 42 of the GNOME runtime.